### PR TITLE
Load a page in settings by default

### DIFF
--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -9,7 +9,7 @@ import RenderSetting from '../components/Settings';
 const Settings = () => {
   const { options } = useOptions();
   const [query, setQuery] = useState('');
-  const [content, setContent] = useState('');
+  const [content, setContent] = useState('Privacy');
 
   const setContentHelp = (name) => {
     if (name === content) setContent('');


### PR DESCRIPTION
Normally, it just opens a blank menu waiting for a user to pick a category

Would be more intuitive if one is already picked and then the user can change